### PR TITLE
Fix release workflow dirty state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           NOTES=$(awk "/^## \[$VERSION\]/{found=1; next} /^## \[/{if(found) exit} found" CHANGELOG.md)
-          echo "$NOTES" > release_notes.md
+          echo "$NOTES" > "$RUNNER_TEMP/release_notes.md"
 
       - name: Setup Go
         if: steps.check-tag.outputs.exists == 'false'
@@ -87,7 +87,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --clean --release-notes release_notes.md
+          args: release --clean --release-notes ${{ runner.temp }}/release_notes.md
         env:
           GITHUB_TOKEN: ${{ github.token }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Removed stale Kong reference from tech stack
+- Fixed release workflow writing notes to working tree
 
 ## [0.3.0] - 2026-02-28
 


### PR DESCRIPTION
## Summary

- Write release notes to `$RUNNER_TEMP` instead of working tree to avoid GoReleaser dirty state error
- Re-set `HOMEBREW_TAP_TOKEN` secret

## Test plan

- [ ] Merge triggers release workflow
- [ ] GoReleaser creates v0.3.1 release with binaries
- [ ] Homebrew formula updated in apermo/homebrew-tap